### PR TITLE
Move Selenium URL for docker into dockerfile-dev

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -11,6 +11,7 @@ RUN mkdir /tests
 VOLUME /tests
 	 
 ENV PYTHONPATH $PYTHONPATH:/app:/tests
+ENV SELENIUM_URL http://standalone-chrome-container:4444/wd/hub 
 
 WORKDIR ./tests
 

--- a/tests/acc/features/environment.py
+++ b/tests/acc/features/environment.py
@@ -17,14 +17,14 @@ Created on Jan 22, 2018
 	limitations under the License.
 '''
 import threading
+import os
 from selenium import webdriver
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.common import desired_capabilities
 
-DOCKER_SELENIUM_URL = "http://standalone-chrome-container:4444/wd/hub"
 LOCAL_SELENIUM_URL = "http://0.0.0.0:4444/wd/hub"
-SELENIUM_URL = DOCKER_SELENIUM_URL
+SELENIUM_URL = os.getenv("SELENIUM_URL", LOCAL_SELENIUM_URL)
 
 DEFAULT_WAIT_TIME_SECONDS = 10
 


### PR DESCRIPTION
Default to local Selenium URL if env for Selenium URL is not defined.